### PR TITLE
Local Devnet macOS Tahoe Docker Prereq Update

### DIFF
--- a/store-and-retrieve-data/spin-up-local-devnet.md
+++ b/store-and-retrieve-data/spin-up-local-devnet.md
@@ -16,7 +16,7 @@ Before you begin, ensure you have the following:
 
     ??? interface "Instructions if running macOS Tahoe (v26 or higher)"
 
-        If running macOS Tahoe (v26 or higher), instead of using Docker, you should install [OrbStack](https://orbstack.dev/download){target=\_blank}. Make sure Docker Desktop is not running while you are using OrbStack in order to allow OrbStack to work properly. You can run all your docker commands the same way while using OrbStack. 
+        If running macOS Tahoe (v26 or higher), instead of using Docker, you should install [OrbStack](https://orbstack.dev/download){target=\_blank}. Make sure Docker Desktop is not running while using OrbStack to ensure it works properly. You can run all your Docker commands the same way while using OrbStack. 
         
         After installing OrbStack, to confirm you are using OrbStack under the hood instead of Docker Desktop, you can run the following command in the terminal:
 


### PR DESCRIPTION
This pull request updates the setup instructions for spinning up a local devnet, specifically to address compatibility with macOS Tahoe (v26 or higher). The main change is the addition of guidance for users on this version of macOS to use OrbStack instead of Docker Desktop.

**Platform-specific setup instructions:**

* Added a callout with instructions for users running macOS Tahoe (v26 or higher) to install and use `OrbStack` instead of Docker Desktop, including how to verify that `OrbStack` is being used by running `docker context show`.