### PR TITLE
update file size limit

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -10,7 +10,7 @@ networks:
     msp_url: https://deo-dh-backend.testnet.datahaven-infra.network/
     chain_id: 55931
     website_faucet_amount: 500 MOCK tokens
-    file_size_limit: 5 MB
+    file_size_limit: 50 MB
     client_version: v0.20.0
   mainnet:
     chain_id: 55930

--- a/variables.yml
+++ b/variables.yml
@@ -10,7 +10,7 @@ networks:
     msp_url: https://deo-dh-backend.testnet.datahaven-infra.network/
     chain_id: 55931
     website_faucet_amount: 500 MOCK tokens
-    file_size_limit: 50 MB
+    file_size_limit: 210 MB
     client_version: v0.20.0
   mainnet:
     chain_id: 55930


### PR DESCRIPTION
This pull request increases the file upload size limit for the testnet environment in the `variables.yml` configuration file.

Configuration update:

* Increased `file_size_limit` for the testnet network from 5 MB to 50 MB in `variables.yml`.