### PR TITLE
Add demo dapp section to docs

### DIFF
--- a/store-and-retrieve-data/use-storagehub-sdk/end-to-end-storage-workflow.md
+++ b/store-and-retrieve-data/use-storagehub-sdk/end-to-end-storage-workflow.md
@@ -477,9 +477,9 @@ Uploading a file does not guarantee network-wide replication. Files are consider
 
 -  <a href="https://github.com/papermoonio/datahaven-demo-dapp" target="_blank" markdown>:material-arrow-right:
 
-    **File Storage Demo Dapp**
+    **File Storage Demo DApp**
 
-    Explore a complete working demo dapp that puts the StorageHub SDK into practice. Check out the source code to see how it all fits together.
+    Explore a complete working demo dApp that puts the StorageHub SDK into practice. Check out the source code to see how it all fits together.
 
     </a>
 

--- a/store-and-retrieve-data/use-storagehub-sdk/end-to-end-storage-workflow.md
+++ b/store-and-retrieve-data/use-storagehub-sdk/end-to-end-storage-workflow.md
@@ -468,11 +468,11 @@ Uploading a file does not guarantee network-wide replication. Files are consider
 
 <div class="grid cards" markdown>
 
--  <a href="/how-it-works/data-and-provider-model/data-flow-and-lifecycle/" markdown>:material-arrow-right: 
-    
-    **Data Flow and Lifecycle**
+-  <a href="https://github.com/papermoonio/datahaven-demo-dapp" target="_blank" markdown>:material-arrow-right:
 
-    End-to-end overview of how data moves through the DataHaven network.
+    **File Storage Demo Dapp**
+
+    Explore a complete working demo dapp that puts the StorageHub SDK into practice. Check out the source code to see how it all fits together.
 
     </a>
 

--- a/store-and-retrieve-data/use-storagehub-sdk/get-started.md
+++ b/store-and-retrieve-data/use-storagehub-sdk/get-started.md
@@ -217,9 +217,33 @@ To interact with DataHaven's Main Storage Provider (MSP) services, you need to e
     - **`getMspHealth`**: Checks the operational health of the MSP and reports whether it’s running normally or facing issues.
     - **`authenticateUser`**: Authenticates your wallet with the MSP via Sign-In With Ethereum (SIWE), creates a session token, and returns your user profile.
 
+## Demo Dapps
+
+To see the StorageHub SDK in action, check out the following open-source demo applications. Both are publicly available and can serve as practical references for building your own dapps on DataHaven.
+
+<div class="grid cards" markdown>
+
+-   :material-file: **File Storage Demo Dapp**
+
+    ---
+
+    A full-featured demo dapp that showcases the core StorageHub SDK workflow, including connecting a wallet, creating buckets, uploading files, and retrieving data from the network.
+
+    [:octicons-arrow-right-24: Live Demo](https://demosdk.datahaven.xyz){target=\_blank} · [:octicons-mark-github-24: Source Code](https://github.com/papermoonio/datahaven-demo-dapp){target=\_blank}
+
+-   :material-image-multiple: **Mortal NFT Demo Dapp**
+
+    ---
+
+    A demo dapp that demonstrates how to use DataHaven as the storage layer for NFT metadata and assets. It walks through minting NFTs with on-chain metadata backed by decentralized storage.
+
+    [:octicons-arrow-right-24: Live Demo](https://demonft.datahaven.xyz){target=\_blank} · [:octicons-mark-github-24: Source Code](https://github.com/papermoonio/datahaven-nft-demo-dapp){target=\_blank}
+
+</div>
+
 ## Next Steps
 
-Now that you have the StorageHub SDK packages installed and all the necessary clients set up, you are ready to start building with DataHaven. 
+Now that you have the StorageHub SDK packages installed and all the necessary clients set up, you are ready to start building with DataHaven.
 
 <div class="grid cards" markdown>
 

--- a/store-and-retrieve-data/use-storagehub-sdk/get-started.md
+++ b/store-and-retrieve-data/use-storagehub-sdk/get-started.md
@@ -296,25 +296,25 @@ const txHash = await walletClient.writeContract({
 
 With both the SDK and the ABI in place, you're ready to follow either path in the guides that follow.
 
-## Demo Dapps
+## Demo DApps
 
-To see the StorageHub SDK in action, check out the following open-source demo applications. Both are publicly available and can serve as practical references for building your own dapps on DataHaven.
+To see the StorageHub SDK in action, check out the following open-source demo applications. Both are publicly available and can serve as practical references for building your own dApps on DataHaven.
 
 <div class="grid cards" markdown>
 
--   :material-file: **File Storage Demo Dapp**
+-   :material-file: **File Storage Demo DApp**
 
     ---
 
-    A full-featured demo dapp that showcases the core StorageHub SDK workflow, including connecting a wallet, creating buckets, uploading files, and retrieving data from the network.
+    A full-featured demo dApp that showcases the core StorageHub SDK workflow, including connecting a wallet, creating buckets, uploading files, and retrieving data from the network.
 
     [:octicons-arrow-right-24: Live Demo](https://demosdk.datahaven.xyz){target=\_blank} · [:octicons-mark-github-24: Source Code](https://github.com/papermoonio/datahaven-demo-dapp){target=\_blank}
 
--   :material-image-multiple: **Mortal NFT Demo Dapp**
+-   :material-image-multiple: **Mortal NFT Demo DApp**
 
     ---
 
-    A demo dapp that demonstrates how to use DataHaven as the storage layer for NFT metadata and assets. It walks through minting NFTs with on-chain metadata backed by decentralized storage.
+    A demo dApp that demonstrates how to use DataHaven as the storage layer for NFT metadata and assets. It walks through minting NFTs with on-chain metadata backed by decentralized storage.
 
     [:octicons-arrow-right-24: Live Demo](https://demonft.datahaven.xyz){target=\_blank} · [:octicons-mark-github-24: Source Code](https://github.com/papermoonio/datahaven-nft-demo-dapp){target=\_blank}
 


### PR DESCRIPTION
- added demo dapp section to `Get Started` page in `Use StorageHub SDK` section
- added CTA at the end of the e2e storage workflow tutorial to link to a demo dapp github repo